### PR TITLE
Fixed moniker

### DIFF
--- a/build/base.sql
+++ b/build/base.sql
@@ -661,7 +661,7 @@ BEGIN
     _new_user := true;
 
     INSERT INTO core.users(account, referral_id)
-    SELECT _account, _referral_id;
+    SELECT LOWER(_account), _referral_id;
 
     /**
      * ----------------------------------------------------------------

--- a/build/db.sql
+++ b/build/db.sql
@@ -928,7 +928,7 @@ BEGIN
   END IF;
 
   INSERT INTO core.monikers(account, name)
-  SELECT _account, _moniker
+  SELECT LOWER(_account), _moniker
   ON CONFLICT DO NOTHING;
 END
 $$
@@ -2072,7 +2072,7 @@ BEGIN
     _new_user := true;
 
     INSERT INTO core.users(account, referral_id)
-    SELECT _account, _referral_id;
+    SELECT LOWER(_account), _referral_id;
 
     /**
      * ----------------------------------------------------------------
@@ -2829,7 +2829,7 @@ BEGIN
     to_timestamp(core.transactions.block_timestamp)::TIMESTAMP WITH TIME ZONE AS date,
     core.transactions.event_name,
     core.transactions.transaction_sender,
-    core.transactions.contract,
+    core.transactions.address,
     core.transactions.transaction_hash,
     core.transactions.block_number,
     %s                                                                  AS page_size,

--- a/build/explorer.sql
+++ b/build/explorer.sql
@@ -97,7 +97,7 @@ BEGIN
     to_timestamp(core.transactions.block_timestamp)::TIMESTAMP WITH TIME ZONE AS date,
     core.transactions.event_name,
     core.transactions.transaction_sender,
-    core.transactions.contract,
+    core.transactions.address,
     core.transactions.transaction_hash,
     core.transactions.block_number,
     %s                                                                  AS page_size,

--- a/sql/base/00-functions/sign_in.sql
+++ b/sql/base/00-functions/sign_in.sql
@@ -44,7 +44,7 @@ BEGIN
     _new_user := true;
 
     INSERT INTO core.users(account, referral_id)
-    SELECT _account, _referral_id;
+    SELECT LOWER(_account), _referral_id;
 
     /**
      * ----------------------------------------------------------------

--- a/sql/rds.sql
+++ b/sql/rds.sql
@@ -928,7 +928,7 @@ BEGIN
   END IF;
 
   INSERT INTO core.monikers(account, name)
-  SELECT _account, _moniker
+  SELECT LOWER(_account), _moniker
   ON CONFLICT DO NOTHING;
 END
 $$


### PR DESCRIPTION
- Update `sign_in` and `generate_moniker` functions to insert the account in lowercase.
- Convert the existing accounts in `core.users` and `core.monikers` tables to lowercase.

```sql
CREATE OR REPLACE FUNCTION sign_in
(
  _account                        text,
  _referral_code                  text,
  _ip_address                     text,
  _user_agent                     jsonb,
  _browser                        text
)
RETURNS jsonb
AS
$$
  ----------------------------------------------------------------
  DECLARE _window                 interval = '10 minutes';
  DECLARE _ban_duration           interval = '6 hours';
  DECLARE _login_limit            integer = 5;
  ----------------------------------------------------------------
  DECLARE _referral_id            uuid;
  DECLARE _user_id                uuid;
  DECLARE _login_id               uuid = uuid_generate_v4();
  DECLARE _login_count            integer;
  DECLARE _new_user               boolean = false;
  DECLARE _moniker                text;
BEGIN
  SELECT referral_id INTO _referral_id
  FROM core.referrals
  WHERE NOT deleted
  AND LOWER(referral_code) = LOWER(_referral_code);

  IF (_referral_id IS NULL AND COALESCE(_referral_code, '') <> '') THEN
    RAISE EXCEPTION USING ERRCODE = 'X1892', MESSAGE = 'Invalid referral code';
    RETURN NULL;
  END IF;

  /**
   * ----------------------------------------------------------------
   * If the user is logging in for the first time, add the user.
   * ----------------------------------------------------------------
   */
  IF NOT EXISTS
  (
    SELECT 1 FROM core.users
    WHERE LOWER(account) = LOWER(_account)
  ) THEN
    _new_user := true;

    INSERT INTO core.users(account, referral_id)
    SELECT LOWER(_account), _referral_id;

    /**
     * ----------------------------------------------------------------
     * For valid referrals, increment the referral count.
     * ----------------------------------------------------------------
     */
    IF(_referral_id IS NOT NULL) THEN
      UPDATE core.referrals
      SET total_referrals = total_referrals + 1
      WHERE referral_id = _referral_id;
    END IF;
  END IF;


  IF(NOT _new_user AND COALESCE(_referral_code, '') <> '') THEN
    RAISE EXCEPTION USING ERRCODE = 'X1892', MESSAGE = 'Invalid referral code';
    RETURN NULL;
  END IF;

  SELECT user_id INTO _user_id
  FROM core.users
  WHERE LOWER(account) = LOWER(_account);

  /**
   * ----------------------------------------------------------------
   * Reject the login if the user is banned.
   * ----------------------------------------------------------------
   */
  IF EXISTS
  (
    SELECT 1 FROM core.users
    WHERE user_id = _user_id 
    AND banned_till > NOW()
  ) THEN
    RAISE EXCEPTION USING ERRCODE = 'X1891', MESSAGE = 'Soft ban for spamming';
    RETURN NULL;
  END IF;

  /**
   * ----------------------------------------------------------------
   * Prevent spam logins when a user makes more than 
   * 5 login attempts within a 10-minute window.
   * ----------------------------------------------------------------
   */
  SELECT COUNT(*) INTO _login_count
  FROM core.logins
  WHERE user_id = _user_id
  AND created_at > NOW() - _window;

  IF(_login_count >= _login_limit) THEN
    UPDATE core.users
    SET banned_till = NOW() + _ban_duration
    WHERE user_id = _user_id;

    RAISE EXCEPTION USING ERRCODE = 'X1893', MESSAGE = 'Login limit exceeded';
    RETURN NULL;
  END IF;

  INSERT INTO core.logins(login_id, user_id, ip_address, user_agent, browser)
  SELECT _login_id, _user_id, _ip_address, _user_agent, _browser;

  PERFORM generate_moniker(_account);

  _moniker := get_name_by_user_id(_user_id);

  RETURN jsonb_build_object
  (
    'loginId', _login_id,
    'moniker', _moniker
  );
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION sign_in OWNER TO writeuser;

CREATE OR REPLACE FUNCTION generate_moniker(_account address)
RETURNS void
VOLATILE
AS
$$
  DECLARE _prefix text[] = '{Abiding, Able, Abounding, Aboveboard, Absolute, Absolved, Abundant, Academic, Acceptable, Accepted, Accepting, Accessible, Acclaimed, Accommodating, Accomplished, Accordant, Accountable, Accredited, Accurate, Accustomed, Acknowledged, Acquainted, Active, Actual, Acuminous, Acute, Adamant, Adaptable, Adept, Adequate, Adjusted, Admirable, Admired, Admissible, Adonic, Adorable, Adored, Adroit, Advanced, Advantaged, Advantageous, Adventuresome, Adventurous, Advisable, Aesthetic, Aesthetical, Affable, Affecting, Affectionate, Affective, Affiliated, Affined, Affluent, Affluential, Ageless, Agile, Agreeable, Aholic, Alacritous, Alert, Alive, Allegiant, Allied, Alluring, Alright, Alternate, Altruistic, Amative, Amatory, Amazing, Ambidextrous, Ambitious, Amelioratory, Amenable, Amiable, Amicable, Amusing, Anamnestic, Angelic, Aplenty, Apollonian, Appealing, Appeasing, Appetent, Appetizing, Apposite, Appreciated, Appreciative, Apprehensible, Approachable, Appropriate, Approving, Apropos, Apt, Ardent, Aristocratic, Arousing, Arresting, Articulate, Artistic, Ascendant, Ascending, Aspirant, Aspiring, Assertive, Assiduous, Assistant, Assisting, Assistive, Associate, Associated, Associative, Assured, Assuring, Astir, Astonishing, Astounding, Astronomical, Astute, Athletic, Attainable, Attendant, Attentive, Attractive, Atypical, Au fait, August, Auspicious, Authentic, Authoritative, Authorized, Autonomous, Available, Avid, Awaited, Awake, Aware, Awash, Awesome, Axiological, Balanced, Baronial, Beaming, Beatific, Beauteous, Beautified, Beautiful, Becoming, Beefy, Believable, Beloved, Benedictory, Benefic, Beneficent, Beneficial, Beneficiary, Benevolent, Benign, Benignant, Bent on, Best, Better, Big, Biggest, Bijou, Blameless, Blazing, Blessed, Blissful, Blithe, Blooming, Bodacious, Boisterous, Bold, Bona fide, Bonny, Bonzer, Boss, Bound, Bounteous, Bountiful, Brainy, Brave, Brawny, Breezy, Brief, Bright, Brill, Brilliant, Brimming, Brisk, Broadminded, Brotherly, Bubbly, Budding, Buff, Bullish, Buoyant, Businesslike, Bustling, Busy, Buxom, Calm, Calmative, Calming, Candescent, Canny, Canty, Capable, Capital, Captivating, Cared for, Carefree, Careful, Caring, Casual, Causative, Celebrated, Celeritous, Celestial, Centered, Central, Cerebral, Certain, Champion, Changeable, Changeless, Charismatic, Charitable, Charming, Cheerful, Cherished, Cherry, Chic, Childlike, Chipper, Chirpy, Chivalrous, Choice, Chosen, Chummy, Civic, Civil, Civilized, Clairvoyant, Classic, Classical, Classy, Clean, Clear, Clearheaded, Clement, Clever, Close, Clubby, Coadjutant, Coequal, Cogent, Cognizant, Coherent, Collected, Colossal, Colourful, Coltish, Comely, Comfortable, Comforting, Comic, Comical, Commanding, Commendable, Commendatory, Commending, Commiserative, Committed, Commodious, Commonsensical, Communicative, Commutual, Companionable, Compassionate, Compatible, Compelling, Competent, Complete, Completed, Complimentary, Composed, Comprehensive, Concentrated, Concise, Conclusive, Concordant, Concrete, Condolatory, Confederate, Conferrable, Confident, Congenial, Congruous, Connected, Conscientious, Conscious, Consensual, Consentaneous, Consentient, Consequential, Considerable, Considerate, Consistent, Consonant, Conspicuous, Constant, Constitutional, Constructive, Contemplative, Contemporary, Content, Contributive, Convenient, Conversant, Convictive, Convincing, Convivial, Cool, Cooperative, Coordinated, Copacetic, Copious, Cordial, Correct, Coruscant, Cosmic, Cosy, Courageous, Courteous, Courtly, Cozy, Crackerjack, Creamy, Creative, Credible, Creditable, Crisp, Crucial, Crystal (Clear), Cuddly, Cultivated, Cultured, Cunning, Curious, Current, Curvaceous, Cushy, Cute, Dainty, Dandy, Dapper, Daring, Darling, Dashing, Dauntless, Dazzling, Dear, Debonair, Decent, Deciding, Decisive, Decorous, Dedicated, Deep, Defiant, Defiantly, Definite, Deft, Delectable, Deliberate, Delicate, Delicious, Delighted, Delightful, Deluxe, Demonstrative, Demulcent, Dependable, Deserving, Designer, Desirable, Desired, Desirous, Destined, Determined, Developed, Developing, Devoted, Devotional, Devout, Dexterous, Didactic, Different, Dignified, Diligent, Dinkum, Diplomatic, Direct, Disarming, Discerning, Disciplined, Discreet, Discrete, Discriminating, Dispassionate, Distinct, Distinctive, Distinguished, Distinguishing, Diverse, Diverting, Divine, Doable, Dominant, Doting, Doubtless, Doughty, Dreamy, Driven, Driving, Durable, Dutiful, Dynamic, Dynamite, Eager, Early, Earnest, Earthly, Earthy, Easy, Easygoing, Ebullient, Eclectic, Economic, Economical, Ecstatic, Ecumenical, Edified, Educated, Educational, Effective, Effectual, Effervescent, Efficient, Effortless, Elaborate, Elated, Elating, Elder, Electric, Electrifying, Eleemosynary, Elegant, Elemental, Eligible, Eloquent, Emerging, Eminent, Empathetic, Employable, Empowered, Enamored, Enchanting, Encouraged, Encouraging, Endearing, Enduring, Energetic, Energizing, Engaging, Enhanced, Enjoyable, Enlightened, Enlightening, Enlivened, Enlivening, Enormous, Enough, Enriching, Enterprising, Entertaining, Enthralling, Enthusiastic, Enticing, Entrancing, Entrepreneurial, Epicurean, Epideictic, Equable, Equal, Equiponderant, Equipped, Equitable, Equivalent, Erotic, Erudite, Especial, Essential, Established, Esteemed, Esthetic, Esthetical, Eternal, Ethical, Euphoric, Eventful, Evident, Evocative, Exact, Exalted, Exceeding, Excellent, Exceptional, Executive, Exhilarating, Exotic, Expansive, Expectant, Expeditious, Expeditive, Expensive, Experienced, Explorative, Expressive, Exquisite, Extraordinary, Exuberant, Exultant, Fab, Fabulous, Facile, Factual, Facultative, Fain, Fair, Faithful, Famed, Familial, Familiar, Family, Famous, Fancy, Fantastic, Fascinating, Fashionable, Fast, Faultless, Favorable, Favored, Favorite, Fearless, Feasible, Fecund, Felicitous, Fertile, Fervent, Festal, Festive, Fetching, Fiery, Fine, Finer, Finest, Firm, First, Fit, Fitting, Flamboyant, Flash, Flashy, Flavorful, Flawless, Fleet, Flexible, Flourishing, Fluent, Flying, Focused, Fond, For real, Forceful, Foremost, Foresighted, Forgiving, Formidable, Forthcoming, Forthright, Fortified, Fortuitous, Fortunate, Forward, Foundational, Foxy, Fragrant, Frank, Fraternal, Free, Freely, Fresh, Friendly, Frisky, Frolicsome, Fruitful, Fulfilled, Fulfilling, Full, Fun, Funny, Futuristic, Gainful, Gallant, Galore, Game, Gamesome, Generous, Genial, Genteel, Gentle, Genuine, Germane, Gettable, Giddy, Gifted, Giving, Glad, Glamorous, Gleaming, Gleeful, Glorious, Glowing, Gnarly, Godly, Golden, Good, Goodhearted, Goodly, Gorgeous, Graced, Graceful, Gracile, Gracious, Gradely, Graithly, Grand, Grateful, Gratified, Gratifying, Great, Greatest, Greathearted, Gregarious, Groovy, Grounded, Growing, Grown, Guaranteed, Gubernatorial, Guided, Guiding, Guileless, Guiltless, Gumptious, Gustatory, Gutsy, Gymnastic, Halcyon, Hale, Hallowed, Handsome, Handy, Happening, Happy, Hardy, Harmless, Harmonious, Head, Healing, Healthful, Healthy, Heartfelt, Hearty, Heavenly, Heedful, Hegemonic, Helpful, Hep, Heralded, Heroic, Heteroclite, Heuristic, High, Highest, Highly regarded, Highly valued, Hilarious, Hip, Holy, Homely, Honest, Honeyed, Honorary, Honorable, Honored, Hopeful, Hortative, Hospitable, Hot, Hotshot, Huggy, Humane, Humanitarian, Humble, Humorous, Hunky, Hygienic, Hypersonic, Hypnotic, Ideal, Idealistic, Idiosyncratic, Idolized, Illimitable, Illuminated, Illuminating, Illustrious, Imaginative, Imitable, Immaculate, Immeasurable, Immediate, Immense, Immortal, Immune, Impartial, Impassioned, Impeccable, Impeccant, Imperturbable, Impish, Important, Impressive, Improved, Improving, Improvisational, In, Incisive, Included, Inclusive, Incomparable, Incomplex, Incontestable, Incontrovertible, Incorrupt, Incredible, Inculpable, Indefatigable, Independent, Indestructible, Indispensable, Indisputable, Individual, Individualistic, Indivisible, Indomitable, Indubitable, Industrious, Inerrant, Inexhaustible, Infallible, Infant, Infinite, Influential, Informative, Informed, Ingenious, Inimitable, Initiate, Initiative, Innocent, Innovative, Innoxious, Inquisitive, Insightful, Inspired, Inspiring, Inspiriting, Instantaneous, Instinctive, Instructive, Instrumental, Integral, Integrated, Intellectual, Intelligent, Intense, Intent, Interactive, Interconnected, Interested, Interesting, Internal, Intertwined, Intimate, Intoxicating, Intrepid, Intriguing, Introducer, Inventive, Invigorated, Invigorating, Invincible, Inviolable, Inviting, Irrefragable, Irrefutable, Irreplaceable, Irrepressible, Irreproachable, Irresistible, Jaculable, Jaunty, Jazzed, Jazzy, Jessant, Jestful, Jesting, Jewelled, Jiggish, Jigjog, Jimp, Jobbing, Jocose, Jocoserious, Jocular, Joculatory, Jocund, Joint, Jointed, Jolif, Jolly, Jovial, Joyful, Joyous, Joysome, Jubilant, Judicious, Juicy, Jump, Just, Justified, Keen, Kempt, Key, Kind, Kindly, Kindred, Kinetic, Kingly, Kissable, Knightly, Knowable, Knowing, Knowledgeable, Kooky, Kosher, Ladylike, Large, Lasting, Latitudinarian, Laudable, Laureate, Lavish, Lawful, Leading, Learned, Legal, Legendary, Legible, Legit, Legitimate, Leisured, Leisurely, Lenien, Leonine, Lepid, Lettered, Liberal, Liberated, Liberating, Lightly, Likable, Like, Liked, Likely, Limber, Lionhearted, Literary, Literate, Lithe, Lithesome, Live, Lively, Logical, Lordly, Lovable, Loved, Lovely, Loving, Loyal, Lucent, Lucid, Lucky, Lucrative, Luminous, Luscious, Lush, Lustrous, Lusty, Luxuriant, Luxurious, Made, Magical, Magnanimous, Magnetic, Magnificent, Maiden, Main, Majestic, Major, Malleable, Manageable, Managerial, Manifest, Manly, Mannerly, Many, Marked, Marvelous, Master, Masterful, Masterly, Matchless, Maternal, Mature, Maturing, Maximal, Meaningful, Mediate, Meditative, Meek, Mellow, Melodious, Memorable, Merciful, Meritable, Meritorious, Merry, Mesmerizing, Metaphysical, Meteoric, Methodical, Meticulous, Mettlesome, Mighty, Mindful, Minikin, Ministerial, Mint, Miraculous, Mirthful, Mitigative, Mitigatory, Model, Modern, Modernistic, Modest, Momentous, Moneyed, Moral, More, Most, Mother, Motivated, Motivating, Motivational, Motor, Moving, Much, Mucho, Multidimensional, Multidisciplined, Multifaceted, Munificent, Muscular, Musical, Must, Mutual, National, Nationwide, Native, Natty, Natural, Nearby, Neat, Necessary, Needed, Neighborly, Neoteric, Nestling, New, Newborn, Nice, Nifty, Nimble, Nippy, Noble, Noetic, Nonchalant, Nonpareil, Normal, Notable, Noted, Noteworthy, Noticeable, Nourished, Nourishing, Novel, Now, Nubile, Number one, Nutrimental, Objective, Obliging, Observant, Obtainable, Oecumenical, Official, OK, Okay, Olympian, On, Once, One, Onward, Open, Operative, Opportune, Optimal, Optimistic, Optimum, Opulent, Orderly, Organic, Organized, Oriented, Original, Ornamental, Outgoing, Outstanding, Overflowing, Overjoyed, Overriding, Overt, Palatable, Pally, Palpable, Par excellence, Paradisiac, Paradisiacal, Paramount, Parental, Parnassian, Participant, Participative, Particular, Partisan, Passionate, Paternal, Patient, Peaceable, Peaceful, Peachy, Peerless, Penetrating, Peppy, Perceptive, Perfect, Perky, Permanent, Permissive, Perseverant, Persevering, Persistent, Personable, Perspective, Perspicacious, Perspicuous, Persuasive, Pert, Pertinent, Pet, Petite, Phenomenal, Philanthropic, Philoprogenitive, Philosophical, Picked, Picturesque, Pierian, Pilot, Pioneering, Pious, Piquant, Pithy, Pivotal, Placid, Plausible, Playful, Pleasant, Pleased, Pleasing, Pleasurable, Plenary, Plenteous, Plentiful, Plenty, Pliable, Plucky, Plummy, Plus, Plush, Poetic, Poignant, Poised, Polished, Polite, Popular, Posh, Positive, Possible, Potent, Potential, Powerful, Practicable, Practical, Practised, Pragmatic, Praiseworthy, Prayerful, Precious, Precise, Predominant, Preeminent, Preferable, Preferred, Premier, Premium, Prepared, Preponderant, Prepotent, Present, Prestigious, Pretty, Prevailing, Prevalent, Prevenient, Primal, Primary, Prime, Prime mover, Primed, Primo, Princely, Principal, Principled, Pristine, Privileged, Prize, Prizewinning, Prized, Pro, Proactive, Probable, Probative, Procurable, Prodigious, Productive, Professional, Proficient, Profitable, Profound, Profuse, Progressive, Prolific, Prominent, Promising, Prompt, Proper, Propertied, Prophetic, Propitious, Prospective, Prosperous, Protean, Protective, Proud, Provocative, Prudent, Psyched up, Puissant, Pukka, Pulchritudinous, Pumped up, Punchy, Punctilious, Punctual, Pure, Purposeful, Quaint, Qualified, Qualitative, Quality, Quantifiable, Queenly, Quemeful, Quick, Quiet, Quietsome, Quintessential, Quirky, Quiver, Quixotic, Quotable, Racy, Rad, Radiant, Rapid, Rapturous, Rational, Reachable, Ready, Real, Realistic, Realizable, Reasonable, Reassuring, Receptive, Recherche, Recipient, Reciprocal, Recognizable, Recognized, Recommendable, Recuperative, Refined, Reflective, Refreshing, Refulgent, Regal, Regnant, Regular, Rejuvenescent, Relaxed, Relevant, Reliable, Relieved, Remarkable, Remissive, Renowned, Reputable, Resilient, Resolute, Resolved, Resounding, Resourceful, Respectable, Respectful, Resplendent, Responsible, Responsive, Restful, Restorative, Retentive, Revealing, Revered, Reverent, Revitalizing, Revolutionary, Rewardable, Rewarding, Rhapsodic, Rich, Right, Righteous, Rightful, Risible, Robust, Rollicking, Romantic, Rooted, Rosy, Round, Rounded, Rousing, Rugged, Ruling, Saccharine, Sacred, Sacrosanct, Safe, Sagacious, Sage, Saintly, Salient, Salubrious, Salutary, Salutiferous, Sanctified, Sanctimonious, Sanctioned, Sanguine, Sapid, Sapient, Sapoforic, Sassy, Satisfactory, Satisfied, Satisfying, Saucy, Saving, Savory, Savvy, Scenic, Scholarly, Scientific, Scintillating, Scrumptious, Scrupulous, Seamless, Seasonal, Seasoned, Secure, Sedulous, Seemly, Select, Selfless, Sensational, Sensible, Sensitive, Sensual, Sensuous, Sentimental, Sequacious, Serendipitous, Serene, Service, Set, Settled, Sexual, Sexy, Shapely, Sharp, Shatterproof, Sheen, Shining, Shiny, Shipshape, Showy, Shrewd, Sightly, Significant, Silken, Silky, Silver, Silvery, Simple, Sincere, Sinewy, Singular, Sisterly, Sizable, Sizzling, Skillful, Skilled, Sleek, Slick, Slinky, Smacking, Smart, Smashing, Smiley, Smooth, Snap, Snappy, Snazzy, Snod, Snug, Soaring, Sociable, Social, Societal, Soft, Soigne, Solicitous, Solid, Sonsy, Sooth, Soothing, Sophisticated, Soulful, Sound, Sovereign, Spacious, Spangly, Spanking, Sparkling, Sparkly, Special, Spectacular, Specular, Speedy, Spellbinding, Spicy, Spiffy, Spirited, Spiritual, Splendid, Splendiferous, Spontaneous, Sport, Sporting, Sportive, Sporty, Spot, Spotless, Spot on, Sprightly, Spruce, Spry, Spunky, Square, Stable, Stacked, Stainless, Stalwart, Staminal, Standard, Standing, Star, Starry, State, Stately, Statuesque, Staunch, Steadfast, Steady, Steamy, Stellar, Sterling, Sthenic, Stimulant, Stimulating, Stimulative, Stipendiary, Stirred, Stirring, Stocky, Stoical, Storied, Stout, Stouthearted, Straightforward, Strapping, Strategic, Streetwise, Strenuous, Striking, Strong, Studious, Stunning, Stupendous, Sturdy, Stylish, Suasive, Suave, Sublime, Substantial, Substant, Substantive, Subtle, Successful, Succinct, Succulent, Sufficient, Sugary, Suitable, Sultry, Summary, Summery, Sumptuous, Sunny, Super, Superabundant, Supereminent, Superethical, Superexcellent, Superb, Supercalifragilisticexpialidocious, Superfluous, Superior, Superlative, Supernal, Supersonic, Supple, Supportive, Supreme, Sure, Surpassing, Sustained, Svelte, Swank, Swashbuckling, Sweet, Swell, Swift, Swish, Sybaritic, Sylvan, Symmetrical, Sympathetic, Symphonious, Synergistic, Systematic, Tactful, Talented, Tangible, Tasteful, Tasty, Teachable, Teeming, Tempean, Temperate, Tenable, Tenacious, Tender, Terrific, Testimonial, Thankful, Thankworthy, Therapeutic, Thorough, Thoughtful, Thrilled, Thrilling, Thriving, Tidy, Tight, Timeless, Timely, Tiptop, Tireless, Titanic, Titillating, Today, Together, Tolerant, Top, Top drawer, Tops, Total, Touching, Tough, Trailblazing, Tranquil, Transcendent, Transcendental, Transient, Transnormal, Transparent, Transpicuous, Traveled, Tremendous, Tretis, Trim, Triumphant, True, Trustful, Trusting, Trustworthy, Trusty, Truthful, Tubular, Tuneful, Turgent, Tympanic, Uber, Ultimate, Ultra, Ultraprecise, Unabashed, Unadulterated, Unaffected, Unafraid, Unalloyed, Unambiguous, Unanimous, Unarguable, Unassuming, Unattached, Unbeaten, Unbelieavable, Unbiased, Unbigoted, Unblemished, Unbroken, Uncommon, Uncomplicated, Unconditional, Uncontestable, Unconventional, Uncorrupted, Uncritical, Undamaged, Undauntable, Undaunted, Undefeated, Undefiled, Undeniable, Under control, Understandable, Understanding, Understood, Undesigning, Undiminished, Undisputed, Undivided, Undoubted, Unencumbered, Unequalled, Unequivocal, Unerring, Unfailing, Unfaltering, Unfaultable, Unfeigned, Unfettered, Unflagging, Unflappable, Ungrudging, Unhampered, Unharmed, Unhesitating, Unhurt, Unified, Unimpaired, Unimpeachable, Unimpeded, Unique, United, Universal, Unlimited, Unmistakable, Unmitigated, Unobjectionable, Unobstructed, Unobtrusive, Unopposed, UnUnprejudiced, Unpretentious, Unquestionable, Unrefuted, Unreserved, Unrivalled, Unruffled, Unselfish, Unshakable, Unshaken, Unspoiled, Unspoilt, Unstoppable, Unsullied, Unsurpassed, Untarnished, Untiring, Untouched, Untroubled, Unusual, Unwavering, Up, Upbeat, Upcoming, Uplifted, Uplifting, Uppermost, Upright, Upstanding, Upward, Upwardly, Urbane, Usable, Useful, Utmost, Valiant, Valid, Validatory, Valorous, Valuable, Valued, Vast, Vaulting, Vehement, Venerable, Venturesome, Venust, Veracious, Verdurous, Veridical, Verified, Versatile, Versed, Very, Vestal, Veteran, Viable, Vibrant, Vibratile, Victor, Victorious, Vigilant, Vigorous, Virile, Virtuous, Visionary, Vital, Vivacious, Vivid, Vocal, Volant, Volitional, Voluptuous, Vulnerary, Wanted, Warm, Warranted, Wealthy, Weighty, Welcome, Welcomed, Welcoming, Weleful, Welfaring, Well, Welsome, Whimsical, Whole, Wholehearted, Wholesome, Whopping, Widely used, Willed, Willing, Winged, Winning, Winsome, Wired, Wise, With it, Within reach, Without equal, Witty, Wizard, Wizardly, Won, Wonderful, Wondrous, Workable, Worldly, Worshipful, Worth, Worthwhile, Worthy, Xenial, Xenodochial, Yern, Young, Youthful, Yummy, Zaftig, Zany, Zappy, Zazzy, Zealed, Zealful, Zealous, Zestful, Zesty, Zingy, Zippy, Zootrophic, Zooty, Affectionate, Agreeable, Amiable, Bright, Charming, Creative, Determined, Diligent, Diplomatic, Dynamic, Energetic, Friendly, Funny, Generous, Giving, Gregarious, Hardworking, Helpful, Imaginative, Kind, Likable, Loyal, Patient, Polite, Sincere, Adept, Brave, Capable, Considerate, Courageous, Faithful, Fearless, Frank, Humorous, Knowledgeable, Loving, Marvelous, Nice, Optimistic, Passionate, Persistent, Plucky, Proficient, Romantic, Sensible, Thoughtful, Warmhearted, Willing, Zestful, Amazing, Awesome, Blithesome, Excellent, Fabulous, Favorable, Fortuitous, Gorgeous, Incredible, Unique, Mirthful, Outstanding, Perfect, Philosophical, Propitious, Remarkable, Rousing, Spectacular, Splendid, Stellar, Stupendous, Super, Upbeat, Stunning, Wondrous, Alluring, Ample, Bountiful, Brilliant, Breathtaking, Dazzling, Elegant, Enchanting, Gleaming, Glimmering, Glistening, Glittering, Glowing, Lovely, Lustrous, Magnificent, Ravishing, Shimmering, Shining, Sleek, Sparkling, Twinkling, Vivid, Vibrant, Vivacious, Adaptable, Ambitious, Approachable, Competitive, Confident, Devoted, Educated, Efficient, Flexible, Focused, Honest, Independent, Inquisitive, Insightful, Organized, Personable, Productive, Qualified, Relaxed, Resourceful, Responsible}';
  DECLARE _suffix text[] = '{Ablation, Absolute Magnitude, Absolute Zero, Accretion, Accretion Disk, Achondrite, Actaea, Adrastea, Aegaeon, Aegir, Aitne, Albedo, Albedo Feature, Albiorix, Altitude, Amalthea, Ananke, Anthe, Antimatter, Antipodal Point, Aoede, Apastron, Aperture, Aphelion, Apogee, Apparent Magnitude, Arche, Ariel, Asteroid, Asteroid, Asteroid, Astrochemistry, Astronomical Unit, Atlas, Atmosphere, Atmosphere, Atom, Aurora, Aurora australis, Aurora Australis, Aurora borealis, Aurora Borealis, Autonoe, Axis, Azimuth, Bar, Bebhionm, Belinda, Bergelmir, Bestla, Bianca, Big Bang, Binary, Black hole, Black Hole, Black Moon, Blue Moon, Blueshift, Bolide, Caldera, Caliban, Callirrhoe, Callisto, Calypso, Carme, Carpo, Catena, Cavus, Celestial Equator, Celestial Poles, Celestial Sphere, Cepheid Variable, Chaldene, Chaos, Charon, Chasma, Chondrite, Chondrule, Chromosphere, Circumpolar Star, Circumstellar Disk, Coma, Comet, Comet, Conjunction, Constellation, Constellation, Cordelia, Corona, Corona, Cosmic Ray, Cosmic String, Cosmogony, Cosmology, Cosmos, Crater, Crater, Cressida, Cupid, Cyllene, Daphnis, Dark Matter, Debris Disk, Declination, Deimos, Density, Desdemona, Despina, Dia, Dione, Disk, Doppler Effect, Double Asteroid, Double Star, Dwarf planet, Dwarf Planet, Dysnomia, Eccentricity, Eclipse, Eclipsing Binary, Ecliptic, Eirene, Ejecta, El Niño, Elara, Electromagnetic Radiation, Electromagnetic Spectrum, Electromagnetic Spectrum, Ellipse, Elliptical Galaxy, Elongation, Enceladus, Ephemeris, Epimetheus, Equator, Equinox, Erinome, Eris, Erriapus, Ersa, Escape Velocity, Euanthe, Eukelade, Eupheme, Euporie, Europa, Eurydome, Event Horizon, Evolved Star, Exoplanet, Extinction, Extragalactic, Extraterrestrial, Eyepiece, Faculae, Farbauti, Fenrir, Ferdinand, Filament, Finder, Fireball, Flare Star, Fornjot, Francisco, Galactic Halo, Galactic Nucleus, Galatea, Galaxy, Galaxy, Galilean Moons, Gamma rays, Gamma-ray, Ganymede, Gas, Geosynchronous Orbit, Giant Molecular Cloud, Globular Cluster, Gonggong, GPS, Granulation, Gravitational Lens, Gravity, Gravity, Greenhouse Effect, Greenhouse gas, Greip, Halimede, Harpalyke, Hati, Haumea , Hegomone, Helene, Helike, Heliopause, Heliosphere, Hermippe, Herse, Hi\iaka, Himalia, Hippocamp, Hydra, Hydrogen, Hydrostatic equilibrium, Hypergalaxy, Hyperion, Hyrrokkin, Iapetus, Ice, Ijiraq, Illmare, Inclination, Inferior Conjunction, Inferior Planet, Infrared, Interplanetary Magnetic Field, Interstellar Medium, Io, Ionosphere, Iron Meteorite, Irregular Galaxy, Irregular Satellite, Isonoe, Jansky, Janus, Jarnsaxa, Jet, Juliet, Kale, Kallichore, Kalyke, Kari, Kelvin, Kerberos, Kiloparsec, Kirkwood Gaps, Kiviuq, Kore, Kuiper Belt, Kuiper Belt, La Niña, Lagrange Point, Laomedeia, Larissa, Leda, Lenticular Galaxy, Libration, Light year, Light Year, Limb, Local Group, Locaste, Loge, Luminosity, Luna, Lunar Eclipse, Lunar Month, Lunation, Lysithea, Mab, Magellanic Clouds, Magnetic field, Magnetic Field, Magnetic Pole, Magnetosphere, Magnitude, Main Belt, Major Planet, Makemake, Mare, Margeret, Mass, Mass, Matter, Matter, Megaclite, Meridian, Metal, Meteor, Meteor, Meteor Shower, Meteorite, Meteorite, Meteoroid, Meteoroid, Methone, Metis, Microwaves, Millibar, Mimas, Minor Planet, Miranda, Mneme, Molecular Cloud, Molecule, Moon, Mundilfari, Nadir, Naiad, Namaka, Narvi, Nebula, Nebula, Nereid, Neso, Neutrino, Neutron star, Neutron Star, Nix, Nova, Nuclear Fusion, Oberon, Oblateness, Obliquity, Occultation, Oort Cloud, Oort Cloud, Open Cluster, Ophelia, Opposition, Orbit, Orbit, Orcus, Orthosie, Ozone layer, Paaliaq, Pallene, Pan, Pandia, Pandora, Parallax, Parsec, Particle, Pasiphae, Pasithee, Patera, Penumbra, Perdita, Perigee, Perihelion, Perturb, Phase, Philphrosyne, Phobos, Phoebe, Photon, Photosphere, Planemo, Planet, Planet, Planetary Nebula, Planetesimal, Planitia, Planum, Plasma, Polydueces, Portia, Praxidike, Precession, Prograde Orbit, Prometheus, Prominence, Proper Motion, Prospero, Proteus, Protoplanetary Disk, Protostar, Psamathe, Puck, Pulsar, Pulsar, Quadrature, Quaoar, Quasar, Quasar, Quasi - Stellar Object, Radial Velocity, Radiant, Radiation, Radiation, Radiation Belt, Radio Galaxy, Radio waves, Radioactive, Red Giant, Redshift, Regular Satellite, Resonance, Retrograde Motion, Retrograde Orbit, Rhea, Right Ascension, Ring Galaxy, Roche Limit, Rosalind, Rotation, Saber\s Beads, Salacia, Sao, Saros Series, Satellite, Satellite, Scarp, Setebos, Seyfert Galaxy, Shell Star, Shepherd Satellite, Siarnaq, Sidereal, Sidereal Month, Sidereal Period, Singularity, Sinope, Skathi, Skoll, Small Solar System Body, Solar Cycle, Solar Eclipse, Solar flare, Solar Flare, Solar Nebula, Solar Panel, Solar system, Solar wind, Solar Wind, Solstice, Space weather, Spacecraft, Spectrometer, Spectroscopy, Spectrum, Speed of Light, Spicules, Spiral Galaxy, Sponde, Star, Star, Star Cluster, Steady State Theory, Stellar Wind, Stephano, Stone Meteorite, Stony Iron, Styx, Sun, Sunspot, Supergiant, Superior Conjunction, Superior Planet, Supermassive, Supermoon, Supernova, Supernova, Supernova Remnant, Surtur, Suttungr, Sycorax, Synchronous Rotation, Synodic Month, Synodic Period, Tarqeq, Tarvos, Taygete, Tectonics, Tektite, Telescope, Telesto, Terminator, Terrestrial, Terrestrial Planet, Tethys, Thalassa, Thebe, Thelxinoe, Themisto, Thrymr, Thyone, Tidal Force, Tidal Heating, Titan, Titania, Trans-Neptunian Object, Transit, Trinculo, Triton (13.4), Trojan, Ultraviolet, Ultraviolet, Umbra, Umbriel, Universal Time, Universe, Vacuum, Van Allen Belts, Vanth, Varda, Variable Star, Virgo Cluster, Visible light, Visible Light, Visual Magnitude, Volcano, Wave, Wavelength, Weywot, White Dwarf, X-Rays, Xiangliu, Yellow Dwarf, Ymir, Zenith, Zodiac, Zodiacal Light}';
  DECLARE _moniker text = CONCAT((array_sample(_prefix, 1))[1], ' ', (array_sample(_suffix, 1))[1]);
BEGIN
  IF(_account IS NULL) THEN
    RETURN;
  END IF;

  INSERT INTO core.monikers(account, name)
  SELECT LOWER(_account), _moniker
  ON CONFLICT DO NOTHING;
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION generate_moniker OWNER TO writeuser;

UPDATE core.users
SET account = LOWER(account)
WHERE account <> LOWER(account);

UPDATE core.monikers
SET account = LOWER(account)
WHERE account <> LOWER(account);

ROLLBACK TRANSACTION;
```

## Update Ownerships (Optional)

```sql
DO
$$
  DECLARE _r record;
BEGIN
  FOR _r IN
    SELECT table_schema, table_name
    FROM information_schema.tables
    WHERE table_schema NOT IN('information_schema', 'pg_catalog')
    ORDER BY table_schema, table_name
  LOOP
    EXECUTE format('ALTER TABLE %I.%I OWNER TO writeuser;', _r.table_schema, _r.table_name);
  END LOOP;

  FOR _r IN
    SELECT table_schema, table_name
    FROM information_schema.views
    WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
    ORDER BY table_schema, table_name
  LOOP
    EXECUTE format('ALTER VIEW %I.%I OWNER TO writeuser;', _r.table_schema, _r.table_name);
  END LOOP;

  FOR _r IN
    SELECT CONCAT(n.nspname, '.', p.proname, '(', pg_catalog.pg_get_function_identity_arguments(p.oid), ')') AS name
    FROM pg_catalog.pg_proc p
    INNER JOIN pg_catalog.pg_namespace n
    ON n.oid = p.pronamespace
    WHERE pg_catalog.pg_function_is_visible(p.oid)
    AND n.nspname NOT IN ('information_schema', 'pg_catalog')
    AND NOT p.proisstrict
  LOOP
    EXECUTE format('ALTER FUNCTION %s OWNER TO writeuser;', _r.name);
  END LOOP;
END
$$
LANGUAGE plpgsql;
```
