### PR TITLE
Fixed `get_name_by_account` function

### DIFF
--- a/build/base.sql
+++ b/build/base.sql
@@ -229,7 +229,7 @@ $$
 BEGIN
   RETURN core.monikers.name
   FROM core.monikers
-  WHERE core.monikers.account = _account;
+  WHERE LOWER(core.monikers.account) = LOWER(_account);
 END
 $$
 LANGUAGE plpgsql;

--- a/build/db.sql
+++ b/build/db.sql
@@ -1640,7 +1640,7 @@ $$
 BEGIN
   RETURN core.monikers.name
   FROM core.monikers
-  WHERE core.monikers.account = _account;
+  WHERE LOWER(core.monikers.account) = LOWER(_account);
 END
 $$
 LANGUAGE plpgsql;
@@ -2829,7 +2829,7 @@ BEGIN
     to_timestamp(core.transactions.block_timestamp)::TIMESTAMP WITH TIME ZONE AS date,
     core.transactions.event_name,
     core.transactions.transaction_sender,
-    core.transactions.contract,
+    core.transactions.address,
     core.transactions.transaction_hash,
     core.transactions.block_number,
     %s                                                                  AS page_size,

--- a/build/explorer.sql
+++ b/build/explorer.sql
@@ -97,7 +97,7 @@ BEGIN
     to_timestamp(core.transactions.block_timestamp)::TIMESTAMP WITH TIME ZONE AS date,
     core.transactions.event_name,
     core.transactions.transaction_sender,
-    core.transactions.contract,
+    core.transactions.address,
     core.transactions.transaction_hash,
     core.transactions.block_number,
     %s                                                                  AS page_size,

--- a/sql/base/00-functions/get_name_by_account.sql
+++ b/sql/base/00-functions/get_name_by_account.sql
@@ -6,7 +6,7 @@ $$
 BEGIN
   RETURN core.monikers.name
   FROM core.monikers
-  WHERE core.monikers.account = _account;
+  WHERE LOWER(core.monikers.account) = LOWER(_account);
 END
 $$
 LANGUAGE plpgsql;


### PR DESCRIPTION
Update `get_name_by_account` to do case-insensitive search

```sql
CREATE OR REPLACE FUNCTION get_name_by_account(_account text)
RETURNS text
STABLE PARALLEL SAFE
AS
$$
BEGIN
  RETURN core.monikers.name
  FROM core.monikers
  WHERE LOWER(core.monikers.account) = LOWER(_account);
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION get_name_by_account OWNER TO writeuser;

ROLLBACK TRANSACTION;
```

## Update Ownerships (Optional)

```sql
DO
$$
  DECLARE _r record;
BEGIN
  FOR _r IN
    SELECT table_schema, table_name
    FROM information_schema.tables
    WHERE table_schema NOT IN('information_schema', 'pg_catalog')
    ORDER BY table_schema, table_name
  LOOP
    EXECUTE format('ALTER TABLE %I.%I OWNER TO writeuser;', _r.table_schema, _r.table_name);
  END LOOP;

  FOR _r IN
    SELECT table_schema, table_name
    FROM information_schema.views
    WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
    ORDER BY table_schema, table_name
  LOOP
    EXECUTE format('ALTER VIEW %I.%I OWNER TO writeuser;', _r.table_schema, _r.table_name);
  END LOOP;

  FOR _r IN
    SELECT CONCAT(n.nspname, '.', p.proname, '(', pg_catalog.pg_get_function_identity_arguments(p.oid), ')') AS name
    FROM pg_catalog.pg_proc p
    INNER JOIN pg_catalog.pg_namespace n
    ON n.oid = p.pronamespace
    WHERE pg_catalog.pg_function_is_visible(p.oid)
    AND n.nspname NOT IN ('information_schema', 'pg_catalog')
    AND NOT p.proisstrict
  LOOP
    EXECUTE format('ALTER FUNCTION %s OWNER TO writeuser;', _r.name);
  END LOOP;
END
$$
LANGUAGE plpgsql;
```
